### PR TITLE
Add chars highlighting

### DIFF
--- a/colors/equinusocio_material.vim
+++ b/colors/equinusocio_material.vim
@@ -140,6 +140,7 @@ call s:HL('Comment', s:colors.comment, s:colors.none, s:colors.none)
 " ----------------------------------------------------
 call s:HL('Constant', s:colors.foreground, s:colors.none, s:colors.none)
 call s:HL('String', s:colors.green, s:colors.none, s:colors.none)
+call s:HL('Character', s:colors.green, s:colors.none, s:colors.none)
 call s:HL('Number', s:colors.orange, s:colors.none, s:colors.none)
 call s:HL('Boolean', s:colors.orange, s:colors.none, s:colors.none)
 call s:HL('Float', s:colors.orange, s:colors.none, s:colors.none)


### PR DESCRIPTION
Chars highlighting didn't work for example in C and C++
For example symbols 'A' or '0' were just white. Now they are highlighted as characters in string.
Before:
<img width="410" alt="Снимок экрана 2021-02-18 в 01 43 15" src="https://user-images.githubusercontent.com/669031/108277872-28924700-718b-11eb-9b7f-356a5553c934.png">
After:
<img width="480" alt="Снимок экрана 2021-02-18 в 01 43 34" src="https://user-images.githubusercontent.com/669031/108277883-2d56fb00-718b-11eb-868f-557f64168fbc.png">
