### PR TITLE
Change color of selected line in quickfix list

### DIFF
--- a/colors/equinusocio_material.vim
+++ b/colors/equinusocio_material.vim
@@ -103,7 +103,7 @@ call s:HL('PmenuSbar', s:colors.none, s:colors.menu_bg, s:colors.none)
 call s:HL('PmenuThumb', s:colors.none, s:colors.foreground, s:colors.none)
 " ----------------------------------------------------
 call s:HL('Question', s:colors.red, s:colors.none, s:colors.none)
-call s:HL('QuickFixLine', s:colors.foreground, s:colors.background, s:colors.none) " link it to normal
+call s:HL('QuickFixLine', s:colors.foreground, s:colors.selection, s:colors.none)
 call s:HL('Search', s:colors.black, s:colors.magenta, s:colors.none)
 call s:HL('SpecialKey', s:colors.black_br, s:colors.none, s:colors.none)
 " ----------------------------------------------------


### PR DESCRIPTION
Selected line in quickfix list wasn't visible, I made it the same color as Visual selection.

Before:
<img width="1065" alt="Снимок экрана 2021-02-25 в 19 13 04" src="https://user-images.githubusercontent.com/669031/109182825-694b1b00-779e-11eb-8273-5420510a229d.png">

After:
<img width="1060" alt="Снимок экрана 2021-02-25 в 19 11 59" src="https://user-images.githubusercontent.com/669031/109182859-6fd99280-779e-11eb-8000-083aebc4e383.png">
