### PR TITLE
Add Constant highlighting

### DIFF
--- a/colors/equinusocio_material.vim
+++ b/colors/equinusocio_material.vim
@@ -138,7 +138,7 @@ call s:HL('WildMenu', s:colors.black, s:colors.cyan, s:colors.none)
 " ----------------------------------------------------
 call s:HL('Comment', s:colors.comment, s:colors.none, s:colors.none)
 " ----------------------------------------------------
-call s:HL('Constant', s:colors.foreground, s:colors.none, s:colors.none)
+call s:HL('Constant', s:colors.cyan, s:colors.none, s:colors.none)
 call s:HL('String', s:colors.green, s:colors.none, s:colors.none)
 call s:HL('Character', s:colors.green, s:colors.none, s:colors.none)
 call s:HL('Number', s:colors.orange, s:colors.none, s:colors.none)


### PR DESCRIPTION
Constants were not highligthed (for example standard constants like NULL or M_PI in C++)

Before:
<img width="180" alt="Снимок экрана 2021-03-07 в 11 10 54" src="https://user-images.githubusercontent.com/669031/110233603-0b54cb00-7f36-11eb-81e0-99de5c415f29.png">

After:
<img width="173" alt="Снимок экрана 2021-03-07 в 11 12 11" src="https://user-images.githubusercontent.com/669031/110233605-10b21580-7f36-11eb-88b6-51991af0e2c1.png">
